### PR TITLE
[SuperEditor][iOS] Cap the jumped position to maxScrollExtent

### DIFF
--- a/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
+++ b/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
@@ -429,7 +429,10 @@ class DragHandleAutoScroller {
         // distance below. Scroll to where the offset sits at the trailing boundary.
         final jumpDeltaToShowOffset =
             offsetInViewport.dy + _dragAutoScrollBoundary.trailing - _getViewportBox().size.height;
-        scrollPosition.jumpTo(currentScrollOffset + jumpDeltaToShowOffset);
+        scrollPosition.jumpTo(
+          (currentScrollOffset + jumpDeltaToShowOffset)
+              .clamp(currentScrollOffset, scrollPosition.maxScrollExtent),
+        );
       }
     }
   }


### PR DESCRIPTION
Sometimes when user hits return, the cursor goes to new line and the scrollview bounces.

Repro steps:
- Before running the example editor, remove the toolbar (`KeyboardEditingToolbar`) and reduce the bottom padding in `defaultStylesheet`
- Run example editor on iOS
- Go to the end of document
- Hit return to create new line

The scroll view bounces because for some reason DragHandleAutoScroller.ensureOffsetIsVisible jumps to a scroll position greater than the maxScrollExtent. I think it's because it adds the drag auto scroll boundary to the jump delta offset.
 It happens on iOS only because of bouncing scroll physics. 

To avoid this, we cap the jump position to maxScrollExtent

before:

https://github.com/BazinC/super_editor/assets/6229343/264eaeb1-ca72-4420-b24c-4d76bdf3d870

after:

https://github.com/BazinC/super_editor/assets/6229343/427e1095-566f-4558-9fef-d9c5de82925f

